### PR TITLE
🔖 Release v0.3.0 - Issue作成順序の安定化

### DIFF
--- a/changelogs/CHANGELOG.md
+++ b/changelogs/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2025-01-01
+
+### Fixed
+
+- **Issue Creation Order Stability**
+  - Fixed non-deterministic issue creation order caused by Go map iteration
+  - Issues with no dependencies are now created in the order they appear in the input file
+  - Maintains original file order when resolving dependencies, only reordering when necessary
+  - Ensures consistent and predictable issue creation order across multiple runs
+
+### Technical Details
+
+- Modified the dependency resolver to preserve original issue order when building the initial queue
+- Changed from iterating over maps to iterating over the original issue slice
+- When new nodes become available for processing after dependency resolution, they are added in file order
+- This fix addresses the issue where independent issues (e.g., INFRA-001) were being created in random positions
+
 ## [0.2.0] - 2025-01-01
 
 ### Added
@@ -122,6 +139,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive error handling including circular dependency detection
 - Support for both GitHub CLI and API authentication methods
 
+[0.3.0]: https://github.com/ef-tech/github-issue-tool/releases/tag/v0.3.0
 [0.2.0]: https://github.com/ef-tech/github-issue-tool/releases/tag/v0.2.0
 [0.1.2]: https://github.com/ef-tech/github-issue-tool/releases/tag/v0.1.2
 [0.1.1]: https://github.com/ef-tech/github-issue-tool/releases/tag/v0.1.1

--- a/changelogs/CHANGELOG_ja.md
+++ b/changelogs/CHANGELOG_ja.md
@@ -5,6 +5,23 @@
 フォーマットは [Keep a Changelog](https://keepachangelog.com/ja/1.0.0/) に基づいており、
 このプロジェクトは [セマンティック バージョニング](https://semver.org/spec/v2.0.0.html) に準拠しています。
 
+## [0.3.0] - 2025-01-01
+
+### 修正
+
+- **Issue作成順序の安定化**
+  - Goのmap反復による非決定的なissue作成順序を修正
+  - 依存関係のないissueは入力ファイルに記載された順序で作成されるようになりました
+  - 依存関係の解決時に元のファイル順序を維持し、必要な場合のみ順序を変更
+  - 複数回の実行にわたって一貫した予測可能なissue作成順序を保証
+
+### 技術的詳細
+
+- 初期キューの構築時に元のissue順序を保持するように依存関係リゾルバを修正
+- mapの反復から元のissueスライスの反復に変更
+- 依存関係解決後に新しいノードが処理可能になった場合、ファイル順序で追加
+- この修正により、独立したissue（例：INFRA-001）がランダムな位置に作成される問題を解決
+
 ## [0.2.0] - 2025-01-01
 
 ### 追加機能
@@ -122,6 +139,7 @@
 - 循環依存検出を含む包括的なエラーハンドリング
 - GitHub CLIとAPI認証方法の両方のサポート
 
+[0.3.0]: https://github.com/ef-tech/github-issue-tool/releases/tag/v0.3.0
 [0.2.0]: https://github.com/ef-tech/github-issue-tool/releases/tag/v0.2.0
 [0.1.2]: https://github.com/ef-tech/github-issue-tool/releases/tag/v0.1.2
 [0.1.1]: https://github.com/ef-tech/github-issue-tool/releases/tag/v0.1.1

--- a/pkg/config/version.go
+++ b/pkg/config/version.go
@@ -2,6 +2,6 @@ package config
 
 const (
 	AppName    = "github-issue-tool"
-	AppVersion = "0.2.0"
+	AppVersion = "0.3.0"
 	AppDesc    = "A smart CLI tool for bulk creation of GitHub issues with dependency management"
 )


### PR DESCRIPTION
## Summary
- Issue作成順序の非決定的な振る舞いを修正
- 依存関係リゾルバの順序保持ロジックを改善
- バージョンを0.3.0に更新

## Changes
### 🐛 Bug Fixes
- **依存関係解決時の順序保持を改善**
  - Goのmap反復による非決定的な順序を修正
  - 依存関係のないissueは入力ファイルの記載順序で作成されるように
  - 複数回実行しても一貫した順序を保証

### 📝 Documentation
- CHANGELOG.mdとCHANGELOG_ja.mdを更新
- v0.3.0の変更内容を記載

## Test Plan
- [x] `go test ./...` - 全てのテストが成功
- [x] `bin/github-issue-tool --dry-run --file ~/Downloads/ddd_architect_issues.md` - INFRA-001が最初に作成されることを確認
- [x] 複数回実行して順序が安定していることを確認

## Related Issues
- 入力ファイルの記載順序が保持されない問題を修正

🤖 Generated with [Claude Code](https://claude.ai/code)